### PR TITLE
Add admin bounty editing commands

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.tcoded</groupId>
     <artifactId>PlayerBountiesPlus</artifactId>
-    <version>1.4.13</version>
+    <version>1.4.14</version>
     <packaging>jar</packaging>
 
     <name>PlayerBountiesPlus</name>

--- a/src/main/java/com/tcoded/playerbountiesplus/command/PlayerBountiesPlusAdminCmd.java
+++ b/src/main/java/com/tcoded/playerbountiesplus/command/PlayerBountiesPlusAdminCmd.java
@@ -18,7 +18,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 public class PlayerBountiesPlusAdminCmd implements CommandExecutor, TabCompleter {
-    private static final ArrayList<String> completions = Lists.newArrayList("reload", "version", "bounty", "help");
+    private static final ArrayList<String> completions = Lists.newArrayList("reload", "version", "admin", "help");
 
     private final PlayerBountiesPlus plugin;
 
@@ -41,7 +41,7 @@ public class PlayerBountiesPlusAdminCmd implements CommandExecutor, TabCompleter
                 return PlayerBountiesPlusReloadCmd.handleCmd(plugin, sender, command, label, args);
             case "version":
                 return PlayerBountiesPlusVersionCmd.handleCmd(plugin, sender, command, label, args);
-            case "bounty":
+            case "admin":
                 return AdminBountyCmd.handleCmd(plugin, sender, command, label, args);
             default:
                 sendHelpMsg(sender);

--- a/src/main/java/com/tcoded/playerbountiesplus/command/PlayerBountiesPlusAdminCmd.java
+++ b/src/main/java/com/tcoded/playerbountiesplus/command/PlayerBountiesPlusAdminCmd.java
@@ -4,6 +4,7 @@ import com.google.common.collect.Lists;
 import com.tcoded.playerbountiesplus.PlayerBountiesPlus;
 import com.tcoded.playerbountiesplus.command.admin.PlayerBountiesPlusReloadCmd;
 import com.tcoded.playerbountiesplus.command.admin.PlayerBountiesPlusVersionCmd;
+import com.tcoded.playerbountiesplus.command.admin.bounty.AdminBountyCmd;
 import org.bukkit.ChatColor;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
@@ -17,7 +18,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 public class PlayerBountiesPlusAdminCmd implements CommandExecutor, TabCompleter {
-    private static final ArrayList<String> completions = Lists.newArrayList("reload", "version", "help");
+    private static final ArrayList<String> completions = Lists.newArrayList("reload", "version", "bounty", "help");
 
     private final PlayerBountiesPlus plugin;
 
@@ -40,6 +41,8 @@ public class PlayerBountiesPlusAdminCmd implements CommandExecutor, TabCompleter
                 return PlayerBountiesPlusReloadCmd.handleCmd(plugin, sender, command, label, args);
             case "version":
                 return PlayerBountiesPlusVersionCmd.handleCmd(plugin, sender, command, label, args);
+            case "bounty":
+                return AdminBountyCmd.handleCmd(plugin, sender, command, label, args);
             default:
                 sendHelpMsg(sender);
                 return true;
@@ -52,6 +55,10 @@ public class PlayerBountiesPlusAdminCmd implements CommandExecutor, TabCompleter
                         "&fAdmin Commands:\n" +
                         "&f/pbp reload &7- Reload the configuration file and the messages.\n" +
                         "&f/pbp version &7- Check the version of the plugin.\n" +
+                        "&f/pbp bounty set <player> <amount> &7- Set a player's bounty.\n" +
+                        "&f/pbp bounty add <player> <amount> &7- Add to a player's bounty.\n" +
+                        "&f/pbp bounty remove <player> <amount> &7- Remove from a player's bounty.\n" +
+                        "&f/pbp bounty delete <player> &7- Delete a player's bounty.\n" +
                         "&f/pbp help &7- Get this message."
         ));
     }

--- a/src/main/java/com/tcoded/playerbountiesplus/command/admin/bounty/AdminBountyAddCmd.java
+++ b/src/main/java/com/tcoded/playerbountiesplus/command/admin/bounty/AdminBountyAddCmd.java
@@ -10,7 +10,7 @@ import java.util.UUID;
 
 public class AdminBountyAddCmd {
 
-    private static final String PERMISSION = "playerbountiesplus.command.playerbountiesplus.bounty.add";
+    private static final String PERMISSION = "playerbountiesplus.command.playerbountiesplus.admin.add";
 
     public static boolean handleCmd(PlayerBountiesPlus plugin, CommandSender sender, Command cmd, String label, String[] args) {
         if (!sender.hasPermission(PERMISSION)) {

--- a/src/main/java/com/tcoded/playerbountiesplus/command/admin/bounty/AdminBountyAddCmd.java
+++ b/src/main/java/com/tcoded/playerbountiesplus/command/admin/bounty/AdminBountyAddCmd.java
@@ -1,0 +1,58 @@
+package com.tcoded.playerbountiesplus.command.admin.bounty;
+
+import com.tcoded.playerbountiesplus.PlayerBountiesPlus;
+import com.tcoded.playerbountiesplus.manager.BountyDataManager;
+import org.bukkit.OfflinePlayer;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandSender;
+
+import java.util.UUID;
+
+public class AdminBountyAddCmd {
+
+    private static final String PERMISSION = "playerbountiesplus.command.playerbountiesplus.bounty.add";
+
+    public static boolean handleCmd(PlayerBountiesPlus plugin, CommandSender sender, Command cmd, String label, String[] args) {
+        if (!sender.hasPermission(PERMISSION)) {
+            String noPerm = plugin.getLang().getColored("command.no-permission");
+            String noPermDetailed = plugin.getLang().getColored("command.no-permission-detailed")
+                    .replace("{no-permission-msg}", noPerm)
+                    .replace("{permission}", PERMISSION);
+            sender.sendMessage(noPermDetailed);
+            return true;
+        }
+
+        if (args.length < 4) {
+            sender.sendMessage(plugin.getLang().getColored("command.admin.bounty.add.missing-args"));
+            return true;
+        }
+
+        String playerName = args[2];
+        int amount;
+        try {
+            amount = Integer.parseInt(args[3]);
+        } catch (NumberFormatException ex) {
+            sender.sendMessage(plugin.getLang().getColored("command.admin.bounty.add.amount-nan"));
+            return true;
+        }
+
+        OfflinePlayer target = plugin.getServer().getOfflinePlayer(playerName);
+        if (target == null || (!target.hasPlayedBefore() && !target.isOnline())) {
+            sender.sendMessage(plugin.getLang().getColored("command.admin.bounty.add.player-not-found"));
+            return true;
+        }
+
+        UUID uuid = target.getUniqueId();
+        BountyDataManager m = plugin.getBountyDataManager();
+        int current = m.getBounty(uuid);
+        int total = current + amount;
+        m.setBounty(uuid, total);
+        m.saveBountiesAsync();
+
+        sender.sendMessage(plugin.getLang().getColored("command.admin.bounty.add.success")
+                .replace("{target}", target.getName())
+                .replace("{amount}", String.valueOf(amount))
+                .replace("{total}", String.valueOf(total)));
+        return true;
+    }
+}

--- a/src/main/java/com/tcoded/playerbountiesplus/command/admin/bounty/AdminBountyCmd.java
+++ b/src/main/java/com/tcoded/playerbountiesplus/command/admin/bounty/AdminBountyCmd.java
@@ -1,0 +1,30 @@
+package com.tcoded.playerbountiesplus.command.admin.bounty;
+
+import com.tcoded.playerbountiesplus.PlayerBountiesPlus;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandSender;
+
+public class AdminBountyCmd {
+
+    public static boolean handleCmd(PlayerBountiesPlus plugin, CommandSender sender, Command cmd, String label, String[] args) {
+        if (args.length < 2) {
+            sender.sendMessage(plugin.getLang().getColored("command.bounty.no-action"));
+            return true;
+        }
+
+        String action = args[1].toLowerCase();
+        switch (action) {
+            case "set":
+                return AdminBountySetCmd.handleCmd(plugin, sender, cmd, label, args);
+            case "add":
+                return AdminBountyAddCmd.handleCmd(plugin, sender, cmd, label, args);
+            case "remove":
+                return AdminBountyRemoveCmd.handleCmd(plugin, sender, cmd, label, args);
+            case "delete":
+                return AdminBountyDeleteCmd.handleCmd(plugin, sender, cmd, label, args);
+            default:
+                sender.sendMessage(plugin.getLang().getColored("command.bounty.invalid-action"));
+                return true;
+        }
+    }
+}

--- a/src/main/java/com/tcoded/playerbountiesplus/command/admin/bounty/AdminBountyDeleteCmd.java
+++ b/src/main/java/com/tcoded/playerbountiesplus/command/admin/bounty/AdminBountyDeleteCmd.java
@@ -10,7 +10,7 @@ import java.util.UUID;
 
 public class AdminBountyDeleteCmd {
 
-    private static final String PERMISSION = "playerbountiesplus.command.playerbountiesplus.bounty.delete";
+    private static final String PERMISSION = "playerbountiesplus.command.playerbountiesplus.admin.delete";
 
     public static boolean handleCmd(PlayerBountiesPlus plugin, CommandSender sender, Command cmd, String label, String[] args) {
         if (!sender.hasPermission(PERMISSION)) {

--- a/src/main/java/com/tcoded/playerbountiesplus/command/admin/bounty/AdminBountyDeleteCmd.java
+++ b/src/main/java/com/tcoded/playerbountiesplus/command/admin/bounty/AdminBountyDeleteCmd.java
@@ -1,0 +1,46 @@
+package com.tcoded.playerbountiesplus.command.admin.bounty;
+
+import com.tcoded.playerbountiesplus.PlayerBountiesPlus;
+import com.tcoded.playerbountiesplus.manager.BountyDataManager;
+import org.bukkit.OfflinePlayer;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandSender;
+
+import java.util.UUID;
+
+public class AdminBountyDeleteCmd {
+
+    private static final String PERMISSION = "playerbountiesplus.command.playerbountiesplus.bounty.delete";
+
+    public static boolean handleCmd(PlayerBountiesPlus plugin, CommandSender sender, Command cmd, String label, String[] args) {
+        if (!sender.hasPermission(PERMISSION)) {
+            String noPerm = plugin.getLang().getColored("command.no-permission");
+            String noPermDetailed = plugin.getLang().getColored("command.no-permission-detailed")
+                    .replace("{no-permission-msg}", noPerm)
+                    .replace("{permission}", PERMISSION);
+            sender.sendMessage(noPermDetailed);
+            return true;
+        }
+
+        if (args.length < 3) {
+            sender.sendMessage(plugin.getLang().getColored("command.admin.bounty.delete.missing-args"));
+            return true;
+        }
+
+        String playerName = args[2];
+        OfflinePlayer target = plugin.getServer().getOfflinePlayer(playerName);
+        if (target == null || (!target.hasPlayedBefore() && !target.isOnline())) {
+            sender.sendMessage(plugin.getLang().getColored("command.admin.bounty.delete.player-not-found"));
+            return true;
+        }
+
+        UUID uuid = target.getUniqueId();
+        BountyDataManager m = plugin.getBountyDataManager();
+        m.removeBounty(uuid);
+        m.saveBountiesAsync();
+
+        sender.sendMessage(plugin.getLang().getColored("command.admin.bounty.delete.success")
+                .replace("{target}", target.getName()));
+        return true;
+    }
+}

--- a/src/main/java/com/tcoded/playerbountiesplus/command/admin/bounty/AdminBountyRemoveCmd.java
+++ b/src/main/java/com/tcoded/playerbountiesplus/command/admin/bounty/AdminBountyRemoveCmd.java
@@ -1,0 +1,63 @@
+package com.tcoded.playerbountiesplus.command.admin.bounty;
+
+import com.tcoded.playerbountiesplus.PlayerBountiesPlus;
+import com.tcoded.playerbountiesplus.manager.BountyDataManager;
+import org.bukkit.OfflinePlayer;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandSender;
+
+import java.util.UUID;
+
+public class AdminBountyRemoveCmd {
+
+    private static final String PERMISSION = "playerbountiesplus.command.playerbountiesplus.bounty.remove";
+
+    public static boolean handleCmd(PlayerBountiesPlus plugin, CommandSender sender, Command cmd, String label, String[] args) {
+        if (!sender.hasPermission(PERMISSION)) {
+            String noPerm = plugin.getLang().getColored("command.no-permission");
+            String noPermDetailed = plugin.getLang().getColored("command.no-permission-detailed")
+                    .replace("{no-permission-msg}", noPerm)
+                    .replace("{permission}", PERMISSION);
+            sender.sendMessage(noPermDetailed);
+            return true;
+        }
+
+        if (args.length < 4) {
+            sender.sendMessage(plugin.getLang().getColored("command.admin.bounty.remove.missing-args"));
+            return true;
+        }
+
+        String playerName = args[2];
+        int amount;
+        try {
+            amount = Integer.parseInt(args[3]);
+        } catch (NumberFormatException ex) {
+            sender.sendMessage(plugin.getLang().getColored("command.admin.bounty.remove.amount-nan"));
+            return true;
+        }
+
+        OfflinePlayer target = plugin.getServer().getOfflinePlayer(playerName);
+        if (target == null || (!target.hasPlayedBefore() && !target.isOnline())) {
+            sender.sendMessage(plugin.getLang().getColored("command.admin.bounty.remove.player-not-found"));
+            return true;
+        }
+
+        UUID uuid = target.getUniqueId();
+        BountyDataManager m = plugin.getBountyDataManager();
+        int current = m.getBounty(uuid);
+        int total = current - amount;
+        if (total <= 0) {
+            m.removeBounty(uuid);
+            total = 0;
+        } else {
+            m.setBounty(uuid, total);
+        }
+        m.saveBountiesAsync();
+
+        sender.sendMessage(plugin.getLang().getColored("command.admin.bounty.remove.success")
+                .replace("{target}", target.getName())
+                .replace("{amount}", String.valueOf(amount))
+                .replace("{total}", String.valueOf(total)));
+        return true;
+    }
+}

--- a/src/main/java/com/tcoded/playerbountiesplus/command/admin/bounty/AdminBountyRemoveCmd.java
+++ b/src/main/java/com/tcoded/playerbountiesplus/command/admin/bounty/AdminBountyRemoveCmd.java
@@ -10,7 +10,7 @@ import java.util.UUID;
 
 public class AdminBountyRemoveCmd {
 
-    private static final String PERMISSION = "playerbountiesplus.command.playerbountiesplus.bounty.remove";
+    private static final String PERMISSION = "playerbountiesplus.command.playerbountiesplus.admin.remove";
 
     public static boolean handleCmd(PlayerBountiesPlus plugin, CommandSender sender, Command cmd, String label, String[] args) {
         if (!sender.hasPermission(PERMISSION)) {

--- a/src/main/java/com/tcoded/playerbountiesplus/command/admin/bounty/AdminBountySetCmd.java
+++ b/src/main/java/com/tcoded/playerbountiesplus/command/admin/bounty/AdminBountySetCmd.java
@@ -10,7 +10,7 @@ import java.util.UUID;
 
 public class AdminBountySetCmd {
 
-    private static final String PERMISSION = "playerbountiesplus.command.playerbountiesplus.bounty.set";
+    private static final String PERMISSION = "playerbountiesplus.command.playerbountiesplus.admin.set";
 
     public static boolean handleCmd(PlayerBountiesPlus plugin, CommandSender sender, Command cmd, String label, String[] args) {
         if (!sender.hasPermission(PERMISSION)) {

--- a/src/main/java/com/tcoded/playerbountiesplus/command/admin/bounty/AdminBountySetCmd.java
+++ b/src/main/java/com/tcoded/playerbountiesplus/command/admin/bounty/AdminBountySetCmd.java
@@ -1,0 +1,55 @@
+package com.tcoded.playerbountiesplus.command.admin.bounty;
+
+import com.tcoded.playerbountiesplus.PlayerBountiesPlus;
+import com.tcoded.playerbountiesplus.manager.BountyDataManager;
+import org.bukkit.OfflinePlayer;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandSender;
+
+import java.util.UUID;
+
+public class AdminBountySetCmd {
+
+    private static final String PERMISSION = "playerbountiesplus.command.playerbountiesplus.bounty.set";
+
+    public static boolean handleCmd(PlayerBountiesPlus plugin, CommandSender sender, Command cmd, String label, String[] args) {
+        if (!sender.hasPermission(PERMISSION)) {
+            String noPerm = plugin.getLang().getColored("command.no-permission");
+            String noPermDetailed = plugin.getLang().getColored("command.no-permission-detailed")
+                    .replace("{no-permission-msg}", noPerm)
+                    .replace("{permission}", PERMISSION);
+            sender.sendMessage(noPermDetailed);
+            return true;
+        }
+
+        if (args.length < 4) {
+            sender.sendMessage(plugin.getLang().getColored("command.admin.bounty.set.missing-args"));
+            return true;
+        }
+
+        String playerName = args[2];
+        int amount;
+        try {
+            amount = Integer.parseInt(args[3]);
+        } catch (NumberFormatException ex) {
+            sender.sendMessage(plugin.getLang().getColored("command.admin.bounty.set.amount-nan"));
+            return true;
+        }
+
+        OfflinePlayer target = plugin.getServer().getOfflinePlayer(playerName);
+        if (target == null || (!target.hasPlayedBefore() && !target.isOnline())) {
+            sender.sendMessage(plugin.getLang().getColored("command.admin.bounty.set.player-not-found"));
+            return true;
+        }
+
+        UUID uuid = target.getUniqueId();
+        BountyDataManager m = plugin.getBountyDataManager();
+        m.setBounty(uuid, amount);
+        m.saveBountiesAsync();
+
+        sender.sendMessage(plugin.getLang().getColored("command.admin.bounty.set.success")
+                .replace("{target}", target.getName())
+                .replace("{bounty}", String.valueOf(amount)));
+        return true;
+    }
+}

--- a/src/main/resources/lang/en_us.yml
+++ b/src/main/resources/lang/en_us.yml
@@ -10,6 +10,26 @@ command:
       reloaded: "&aSuccessfully reloaded the configuration files!"
     version:
       no-permission: "&7(Version not visible: Missing permission)"
+    bounty:
+      set:
+        missing-args: "&cUsage: /pbp bounty set <player> <amount>"
+        amount-nan: "&cThat's not a valid number!"
+        player-not-found: "&cThat player is not online or doesn't exist!"
+        success: "&aSet {target}'s bounty to {bounty}."
+      add:
+        missing-args: "&cUsage: /pbp bounty add <player> <amount>"
+        amount-nan: "&cThat's not a valid number!"
+        player-not-found: "&cThat player is not online or doesn't exist!"
+        success: "&aAdded {amount} bounty to {target}. Total: {total}."
+      remove:
+        missing-args: "&cUsage: /pbp bounty remove <player> <amount>"
+        amount-nan: "&cThat's not a valid number!"
+        player-not-found: "&cThat player is not online or doesn't exist!"
+        success: "&aRemoved {amount} bounty from {target}. Total: {total}."
+      delete:
+        missing-args: "&cUsage: /pbp bounty delete <player>"
+        player-not-found: "&cThat player is not online or doesn't exist!"
+        success: "&aDeleted bounty for {target}."
   bounty:
     no-action: "&cYou need to specify an action! /bounty <set/top/check>"
     invalid-action: "&cThat's not a valid action!"

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -32,11 +32,11 @@ permissions:
         default: true
       playerbountiesplus.command.playerbountiesplus.reload:
         default: op
-      playerbountiesplus.command.playerbountiesplus.bounty.set:
+      playerbountiesplus.command.playerbountiesplus.admin.set:
         default: op
-      playerbountiesplus.command.playerbountiesplus.bounty.add:
+      playerbountiesplus.command.playerbountiesplus.admin.add:
         default: op
-      playerbountiesplus.command.playerbountiesplus.bounty.remove:
+      playerbountiesplus.command.playerbountiesplus.admin.remove:
         default: op
-      playerbountiesplus.command.playerbountiesplus.bounty.delete:
+      playerbountiesplus.command.playerbountiesplus.admin.delete:
         default: op

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -32,3 +32,11 @@ permissions:
         default: true
       playerbountiesplus.command.playerbountiesplus.reload:
         default: op
+      playerbountiesplus.command.playerbountiesplus.bounty.set:
+        default: op
+      playerbountiesplus.command.playerbountiesplus.bounty.add:
+        default: op
+      playerbountiesplus.command.playerbountiesplus.bounty.remove:
+        default: op
+      playerbountiesplus.command.playerbountiesplus.bounty.delete:
+        default: op


### PR DESCRIPTION
## Summary
- add admin bounty set/add/remove/delete commands
- register permissions for the new commands
- document new admin commands in help message
- provide English lang strings for admin commands

## Testing
- `mvn -q -DskipTests package` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68417c11240c832c9b92729281eb5de2