### PR TITLE
Add hasbounty placeholder to PlaceholderAPI hook

### DIFF
--- a/src/main/java/com/tcoded/playerbountiesplus/hook/placeholder/PlaceholderAPIHook.java
+++ b/src/main/java/com/tcoded/playerbountiesplus/hook/placeholder/PlaceholderAPIHook.java
@@ -53,6 +53,8 @@ public class PlaceholderAPIHook extends PlaceholderExpansion implements Placehol
     public @Nullable String onRequest(OfflinePlayer player, @NotNull String params) {
         if (params.equals("bounty")) {
             return String.valueOf(pbpPlugin.getBountyDataManager().getBounty(player.getUniqueId()));
+        } else if (params.equals("hasbounty")) {
+            return String.valueOf(pbpPlugin.getBountyDataManager().hasBounty(player.getUniqueId()));
         }
 
         return "INVALID-OPTION";


### PR DESCRIPTION
## Summary
- add `hasbounty` sub-placeholder to the PlaceholderAPI hook

## Testing
- `mvn -DskipTests package` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 or one of its dependencies could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_68961d9e4de4832c8b4f25a83daa4c2d