### PR TITLE
feat: add GUI framework

### DIFF
--- a/src/main/java/com/tcoded/playerbountiesplus/PlayerBountiesPlus.java
+++ b/src/main/java/com/tcoded/playerbountiesplus/PlayerBountiesPlus.java
@@ -12,6 +12,7 @@ import com.tcoded.playerbountiesplus.hook.placeholder.PlaceholderHook;
 import com.tcoded.playerbountiesplus.hook.team.AbstractTeamHook;
 import com.tcoded.playerbountiesplus.hook.team.TeamHook;
 import com.tcoded.playerbountiesplus.listener.DeathListener;
+import com.tcoded.playerbountiesplus.listener.GuiListener;
 import com.tcoded.playerbountiesplus.manager.BountyDataManager;
 import com.tcoded.playerbountiesplus.util.LangUtil;
 import org.bstats.bukkit.Metrics;
@@ -95,8 +96,9 @@ public final class PlayerBountiesPlus extends JavaPlugin {
             adminCmd.setTabCompleter(adminExec);
         }
 
-        // Listener
+        // Listeners
         this.getServer().getPluginManager().registerEvents(new DeathListener(this), this);
+        this.getServer().getPluginManager().registerEvents(new GuiListener(), this);
 
         // Update checker
         checkUpdate();

--- a/src/main/java/com/tcoded/playerbountiesplus/gui/IPbpGui.java
+++ b/src/main/java/com/tcoded/playerbountiesplus/gui/IPbpGui.java
@@ -1,0 +1,14 @@
+package com.tcoded.playerbountiesplus.gui;
+
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.inventory.InventoryHolder;
+
+public interface IPbpGui extends InventoryHolder {
+
+    void open();
+
+    void setContents();
+
+    void handleClick(InventoryClickEvent event);
+}
+

--- a/src/main/java/com/tcoded/playerbountiesplus/gui/MainBountyGui.java
+++ b/src/main/java/com/tcoded/playerbountiesplus/gui/MainBountyGui.java
@@ -1,0 +1,50 @@
+package com.tcoded.playerbountiesplus.gui;
+
+import com.tcoded.playerbountiesplus.PlayerBountiesPlus;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.inventory.Inventory;
+
+public class MainBountyGui implements IPbpGui {
+
+    private final PlayerBountiesPlus plugin;
+    private final Player viewer;
+    private final Inventory inventory;
+
+    public MainBountyGui(PlayerBountiesPlus plugin, Player viewer) {
+        this.plugin = plugin;
+        this.viewer = viewer;
+
+        // Create inventory
+        this.inventory = Bukkit.createInventory(
+                this,
+                9 * 3,
+                plugin.getLang().getColored("gui.main.title")
+        );
+    }
+
+    @Override
+    public Inventory getInventory() {
+        return this.inventory;
+    }
+
+    @Override
+    public void open() {
+        setContents();
+
+        // Open the inventory for the viewer
+        viewer.openInventory(this.inventory);
+    }
+
+    @Override
+    public void setContents() {
+        // TODO: Populate the inventory
+    }
+
+    @Override
+    public void handleClick(InventoryClickEvent event) {
+        // TODO: Handle inventory clicks
+    }
+}
+

--- a/src/main/java/com/tcoded/playerbountiesplus/listener/GuiListener.java
+++ b/src/main/java/com/tcoded/playerbountiesplus/listener/GuiListener.java
@@ -1,0 +1,28 @@
+package com.tcoded.playerbountiesplus.listener;
+
+import com.tcoded.playerbountiesplus.gui.IPbpGui;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.inventory.InventoryHolder;
+
+public class GuiListener implements Listener {
+
+    @EventHandler
+    public void onInventoryClick(InventoryClickEvent event) {
+        // Get the inventory holder
+        InventoryHolder holder = event.getView().getTopInventory().getHolder();
+
+        // Ensure the holder is a GUI
+        if (!(holder instanceof IPbpGui gui)) {
+            return;
+        }
+
+        // Cancel normal click behaviour
+        event.setCancelled(true);
+
+        // Delegate the click handling
+        gui.handleClick(event);
+    }
+}
+

--- a/src/main/resources/lang/en_us.yml
+++ b/src/main/resources/lang/en_us.yml
@@ -57,3 +57,8 @@ command:
     top:
       top-10: "&eTop 10 bounties:"
       no-bounties: "&r &cNo bounties were set!"
+
+gui:
+  main:
+    title: "&eBounties"
+


### PR DESCRIPTION
## Summary
- add GUI contract interface for opening, populating and handling clicks
- implement placeholder MainBountyGui using language-based inventory titles
- register global GuiListener to delegate inventory clicks

## Testing
- `mvn -e -q test` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68962874feb4832ca8a869c5cb56d267