### PR TITLE
Add ClansPlus team hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ PlayerBountiesPlus lets players set and claim bounties while blocking teammates 
 
 ## Features
 - Clan-aware bounty system that prevents teammates from claiming each other's bounties
-- Integrates with Vault and supports ClansLite, Parties, BetterTeams, SimpleClans and Towny for team detection
+- Integrates with Vault and supports ClansLite, ClansPlus, Parties, BetterTeams, SimpleClans and Towny for team detection
 - Inventory GUI for viewing bounties
 - PlaceholderAPI support for custom placeholders
 - Localized messages in multiple languages

--- a/pom.xml
+++ b/pom.xml
@@ -119,6 +119,12 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>com.github.CortezRomeo</groupId>
+            <artifactId>ClansPlus</artifactId>
+            <version>2.8</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>com.github.TechnicallyCoded</groupId>
             <artifactId>FoliaLib</artifactId>
             <version>0.4.3</version>

--- a/src/main/java/com/tcoded/playerbountiesplus/hook/team/ClansPlusHook.java
+++ b/src/main/java/com/tcoded/playerbountiesplus/hook/team/ClansPlusHook.java
@@ -1,0 +1,39 @@
+package com.tcoded.playerbountiesplus.hook.team;
+
+import com.cortezromeo.clansplus.api.ClanPlus;
+import com.cortezromeo.clansplus.api.storage.IPlayerData;
+import com.tcoded.playerbountiesplus.PlayerBountiesPlus;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.Plugin;
+import org.jetbrains.annotations.Nullable;
+
+public class ClansPlusHook extends AbstractTeamHook {
+
+    private final ClanPlus api;
+
+    public ClansPlusHook(PlayerBountiesPlus plugin, Plugin teamPlugin) {
+        super(plugin, teamPlugin);
+        this.api = Bukkit.getServicesManager().getRegistration(ClanPlus.class).getProvider();
+    }
+
+    private @Nullable String getClanId(Player player) {
+        IPlayerData data = api.getPluginDataManager().getPlayerDatabase(player.getName());
+        if (data == null) {
+            api.getPluginDataManager().loadPlayerDatabase(player.getName());
+            data = api.getPluginDataManager().getPlayerDatabase(player.getName());
+            if (data == null) return null;
+        }
+        String clan = data.getClan();
+        return clan == null || clan.isEmpty() ? null : clan;
+    }
+
+    @Override
+    public boolean isFriendly(Player player1, Player player2) {
+        String clan1 = getClanId(player1);
+        if (clan1 == null) return false;
+        String clan2 = getClanId(player2);
+        if (clan2 == null) return false;
+        return clan1.equalsIgnoreCase(clan2);
+    }
+}

--- a/src/main/java/com/tcoded/playerbountiesplus/hook/team/TeamHook.java
+++ b/src/main/java/com/tcoded/playerbountiesplus/hook/team/TeamHook.java
@@ -45,7 +45,13 @@ public interface TeamHook {
         // LlmDl - Towny - https://www.spigotmc.org/resources/towny-advanced.72694/
         Plugin townyPlugin = pluginManager.getPlugin("Towny");
         if (townyPlugin != null && townyPlugin.isEnabled()) {
-            return new TownyHook(plugin, simpleClansPlugin);
+            return new TownyHook(plugin, townyPlugin);
+        }
+
+        // CortezRomeo - ClansPlus - https://github.com/CortezRomeo/ClansPlus
+        Plugin clansPlusPlugin = pluginManager.getPlugin("ClansPlus");
+        if (clansPlusPlugin != null && clansPlusPlugin.isEnabled()) {
+            return new ClansPlusHook(plugin, clansPlusPlugin);
         }
 
         return null;

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -11,6 +11,7 @@ depend:
   - Vault
 softdepend:
   - ClansLite
+  - ClansPlus
   - Parties
   - BetterTeams
   - SimpleClans


### PR DESCRIPTION
## Summary
- integrate ClansPlus as a team detection hook
- document ClansPlus support and add soft-depend entry
- use ClansPlus API directly and check for hook last in search order

## Testing
- `mvn -q -DskipTests package` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 or one of its dependencies could not be resolved: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b112e69db4832c87a856cd11ac609e